### PR TITLE
Fix mobile menu and navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,28 +45,28 @@
                     </div>
                     <div class="nav-div-wrapper">
                         <div class="nav-div">
-                                <a class="nav-link margin-right-large" href="#contact-page" title="Kontakt oss via telefon">
+                                <a class="nav-link margin-right-large" href="#contact-page" title="Kontakt oss via telefon" onclick="toggleMobileMenuNavLink()">
                                     <svg class="nav-icon padding-top-mini" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-labelledby="telephone-nav-icon" role="img">
                                         <title id="telephone-nav-icon">Kontakt oss via telefon</title>
                                         <use href="#telephone-icon"></use>
                                     </svg>
                                     Kontakt
                                 </a>
-                            <a class="nav-link margin-right-large" href="#about-page" title="Informasjon om oss">
+                            <a class="nav-link margin-right-large" href="#about-page" title="Informasjon om oss" onclick="toggleMobileMenuNavLink()">
                                 <svg class="nav-icon padding-top-mini" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-labelledby="about-nav-icon" role="img">
                                     <title id="about-nav-icon">Informasjon om oss</title>
                                     <use href="#about-icon"></use>
                                 </svg>
                                 Om oss
                             </a>
-                            <a class="nav-link margin-right-large" href="#find-page" title="Informasjon om hvordan du finner oss">
+                            <a class="nav-link margin-right-large" href="#find-page" title="Informasjon om hvordan du finner oss" onclick="toggleMobileMenuNavLink()">
                                 <svg class="nav-icon padding-top-mini" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-labelledby="find-nav-icon" role="img">
                                     <title id="find-nav-icon">Informasjon om hvordan du finner oss</title>
                                     <use href="#find-icon"></use>
                                 </svg>
                                 Finn oss
                             </a>
-                            <a class="nav-link" href="#diseases-page" title="Informasjon om øyesykdommer">
+                            <a class="nav-link" href="#diseases-page" title="Informasjon om øyesykdommer" onclick="toggleMobileMenuNavLink()">
                                 <svg class="nav-icon padding-top-mini" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-labelledby="disease-nav-icon" role="img">
                                     <title id="disease-nav-icon">Informasjon om øyesykdommer</title>
                                     <use href="#disease-icon"></use>
@@ -77,7 +77,7 @@
                     </div>
                 </nav>
             </div>
-            <div id="landing-page-background-div" class="margin-top-very-large margin-bottom-massive">
+            <div id="landing-page-background-div" class="margin-top-very-large margin-bottom-very-large">
                 <div id="landing-page">
                     <div class="left-side">
                         <h1 class="section-heading title margin-bottom-medium">Haugesund Øyelegesenter</h1>
@@ -88,7 +88,7 @@
                     <img class="landing-graphic" src="assets/vector_graphics/landing_graphic_alt_seven.svg" alt="Landing page graphic">
                 </div>
             </div>
-            <div id="about-page" class="full-page-background about-background-color margin-bottom-massive">
+            <div id="about-page" class="full-page-background about-background-color margin-bottom-very-large padding-top-very-large">
                 <div class="full-page layout column-gap-very-large">
                     <div class="left-side">
                         <h1 class="section-heading margin-bottom-medium">Hvem er vi?</h1>
@@ -112,7 +112,7 @@
                     </div>
                 </div>
             </div>
-            <div id="find-page" class="full-page-background find-background-color margin-bottom-massive">
+            <div id="find-page" class="full-page-background find-background-color margin-bottom-very-large padding-top-very-large">
                 <div class="full-page layout column-gap-very-large">
                     <div class="left-side">
                         <h1 class="section-heading margin-bottom-medium">Hvor finner du oss?</h1>
@@ -139,7 +139,7 @@
                     </div>
                 </div>
             </div>
-            <div id="diseases-page" class="full-page-background diseases-background-color margin-bottom-massive">
+            <div id="diseases-page" class="full-page-background diseases-background-color margin-bottom-very-large padding-top-very-large">
                 <div class="full-page diseases-layout">
                     <h1 class="section-heading margin-bottom-medium">Øyesykdommer</h1>
                     <span class="heading-accent margin-bottom-medium"></span>
@@ -229,7 +229,7 @@
                     </div>
                 </div>
             </div>
-            <div id="contact-page" class="full-page-background contact-background-color margin-bottom-very-large">
+            <div id="contact-page" class="full-page-background contact-background-color margin-bottom-contact padding-top-very-large">
                 <div class="full-page layout column-gap-very-large">
                     <div class="left-side">
                         <h1 class="section-heading margin-bottom-medium">Kontakt oss</h1>

--- a/navigation.js
+++ b/navigation.js
@@ -5,14 +5,39 @@ function toggleMobileMenu() {
     const navDiv = document.querySelector(".navbar-div");
     const menuIcon = document.querySelector(".menu-icon");
     const continueIcon = document.querySelector(".continue-icon");
+    const body = document.querySelector("body");
+    const navLinks = document.querySelectorAll(".nav-link");
 
     if (!nav.classList.contains("responsive")) {
+        body.classList.add("stop-scroll");
         nav.classList.add("responsive");
+        nav.classList.remove("padding-bottom-small");
         navDiv.classList.add("navbar-div-responsive");
         menuIcon.classList.add("rotate");
         continueIcon.classList.add("continue-icon-responsive");
+        navLinks.forEach(link => link.classList.add("animate__animated", "animate__fadeInUp"));
     }   else {
+        body.classList.remove("stop-scroll");
         nav.classList.remove("responsive");
+        nav.classList.add("padding-bottom-small");
+        navDiv.classList.remove("navbar-div-responsive");
+        menuIcon.classList.remove("rotate");
+        continueIcon.classList.remove("continue-icon-responsive");
+        navLinks.forEach(link => link.classList.remove("animate__animated", "animate__fadeInUp"));
+    }
+}
+
+function toggleMobileMenuNavLink() {
+    const nav = document.querySelector(".navbar");
+    const navDiv = document.querySelector(".navbar-div");
+    const menuIcon = document.querySelector(".menu-icon");
+    const continueIcon = document.querySelector(".continue-icon");
+    const body = document.querySelector("body");
+
+    if (nav.classList.contains("responsive")) {
+        body.classList.remove("stop-scroll");
+        nav.classList.remove("responsive");
+        nav.classList.add("padding-bottom-small");
         navDiv.classList.remove("navbar-div-responsive");
         menuIcon.classList.remove("rotate");
         continueIcon.classList.remove("continue-icon-responsive");

--- a/style.css
+++ b/style.css
@@ -115,6 +115,7 @@ a {
     top: 0;
     z-index: 3;
     backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px); /* For mobile devices and safari */
 }
 
 .full-page {
@@ -299,6 +300,10 @@ a {
     margin-bottom: 12.8rem;
 }
 
+.margin-bottom-contact {
+    margin-bottom: 12.8rem;
+}
+
 .margin-bottom-massive {
     margin-bottom: 25.6rem;
 }
@@ -329,6 +334,10 @@ a {
 
 .padding-top-medium {
     padding-top: 3.2rem;
+}
+
+.padding-top-very-large {
+    padding-top: 12.8rem;
 }
 
 .padding-bottom-small {
@@ -495,9 +504,9 @@ a {
 }
 
 .menu-icon {
-    transition: transform 0.2s ease, stroke 0.2s ease;
     display: none;
     stroke: var(--color-text-primary);
+    transition: transform 0.2s ease, stroke 0.2s ease;
 }
 
 .heading-accent {
@@ -626,6 +635,7 @@ a {
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--color-text-primary);
+    transition: color 0.2s ease;
 }
 
 .about-background-color {
@@ -744,6 +754,10 @@ a {
 
 .hide {
     display: none;
+}
+
+.stop-scroll {
+    overflow: hidden;
 }
 
 .border-bottom {
@@ -920,16 +934,7 @@ body.header-not-at-top .continue-icon {
 
     .navbar-div-responsive {
         background-color: var(--color-primary-900);
-        transition: background-color 0.8s ease;
-    }
-
-    .navbar-div-responsive .logo, .navbar-div-responsive .nav-link, .navbar-div-responsive .menu-icon {
-        color: var(--color-text-white);
-        stroke: var(--color-text-white);
-    }
-
-    .navbar-div-responsive .nav-link {
-        border-bottom: 2px solid var(--color-text-white);
+        transition: background-color 0.2s ease;
     }
 
     .nav-div {
@@ -949,7 +954,7 @@ body.header-not-at-top .continue-icon {
     }
 
     .responsive .nav-div-wrapper {
-        height: calc(100vh - 8.9rem);
+        height: calc(100vh - 5.8rem);
         display: flex;
         justify-content: center;
         align-items: center;
@@ -961,10 +966,17 @@ body.header-not-at-top .continue-icon {
         align-items: center;
     }
 
+    .responsive .logo, .responsive .menu-icon {
+        color: var(--color-text-white);
+        stroke: var(--color-text-white);
+    }
+
     .responsive .nav-link {
         display: block;
         text-align: center;
+        color: var(--color-text-white);
         font-size: var(--text-size-nav-link-open);
+        border-bottom: 2px solid var(--color-text-white);
     }
 
     /* Remove the icons for the nav links */
@@ -1029,6 +1041,10 @@ body.header-not-at-top .continue-icon {
     }
 
     .margin-bottom-very-large {
+        margin-bottom: 0rem;
+    }
+
+    .margin-bottom-contact {
         margin-bottom: 6.4rem;
     }
 


### PR DESCRIPTION
- Mobile menu now covers the entire page when opened

- Ability to scroll content behind mobile menu removed

- Mobile menu now closes automatically when nav links are clicked

- Nav links now jump to correct position

- Nav links now animate on opening mobile menu

- Navbar is now transparent

This pull request closes #18 and #20.