### PR TITLE
Add alt text to images on about us page

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,21 +93,21 @@
                     <div class="about-cards-wrapper">
                         <div class="about-card">
                             <span class="card-accent"></span>
-                            <img class="about-card-image about-card-image-friendly margin-top-none margin-bottom-medium" src="assets/images/friendly.png">
+                            <img class="about-card-image about-card-image-friendly margin-top-none margin-bottom-medium" src="assets/images/friendly.png" alt="Friendly doctor talking with a patient">
                             <h3 class="about-card-header margin-top-none margin-bottom-small">Vennlighet</h3>
                             <span class="heading-accent margin-bottom-small"></span>
                             <p class="normal-text center-text margin-top-none margin-bottom-none">Vi i Haugesund Øyelegesenter er en vennlig gjeng. Når du besøker oss i klinikken vår, vil vi møte deg med et smil og du vil med en gang føle deg ivaretatt. Vi mener man kommer langt med litt vennlighet.</p>
                         </div>
                         <div class="about-card">
                             <span class="card-accent"></span>
-                            <img class="about-card-image about-card-image-safety margin-top-none margin-bottom-medium" src="assets/images/safety.png">
+                            <img class="about-card-image about-card-image-safety margin-top-none margin-bottom-medium" src="assets/images/safety.png" alt="Doctor consulting with a patient and its parent">
                             <h3 class="about-card-header margin-top-none margin-bottom-small">Trygghet</h3>
                             <span class="heading-accent margin-bottom-small"></span>
                             <p class="normal-text center-text margin-top-none margin-bottom-none">Vi er opptatt av at du skal føle deg trygg hos oss. Hvis du er redd for noe eller har noen spørsmål, er det bare å <a class="external-link" href="#contact-page">ta kontakt med oss</a>. Enten via telefon eller i klinikken. Vi sørger for at du alltid er informert hele veien. </p>
                         </div>
                         <div class="about-card">
                             <span class="card-accent"></span>
-                            <img class="about-card-image about-card-image-skill margin-top-none margin-bottom-medium" src="assets/images/skill.png">
+                            <img class="about-card-image about-card-image-skill margin-top-none margin-bottom-medium" src="assets/images/skill.png" alt="Two doctors analyzing the human body on a blackboard">
                             <h3 class="about-card-header margin-top-none margin-bottom-small">Kompetanse</h3>
                             <span class="heading-accent margin-bottom-small"></span>
                             <p class="normal-text center-text margin-top-none margin-bottom-none">Våre ansatte er opptatt av å levere et høyt nivå av kompetanse for deg som pasient. Vi har drevet klinikk i Haugesund siden 2013, og har i løpet av årene perfeksjonert behandlingsmetodene våre.</p>


### PR DESCRIPTION
Added alt text which describe the images to all the images on the about us page.

This pull request closes #46.