### PR TITLE
Fix top-button showing on mobile menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
             <div class="navbar-div center-items">
                 <nav class="navbar padding-top-small padding-bottom-small">
                     <div class="nav-top-row">
-                        <a class="logo" href="#main-div" title="Gå til starten">
+                        <a class="logo" href="#main-div" title="Gå til starten" onclick="toggleMobileMenuNavLink(this)">
                             <img class="margin-right-small" width="60" height="73" src="assets/vector_graphics/logo.svg" alt="Haugesund Øyelegesenter logo" loading="lazy" decoding="async">
                             Haugesund<br>Øyelegesenter
                         </a>
@@ -47,28 +47,28 @@
                     </div>
                     <div class="nav-div-wrapper">
                         <div class="nav-div">
-                            <a class="nav-link margin-right-large" href="#about-page" title="Informasjon om oss" onclick="toggleMobileMenuNavLink()">
+                            <a id="nav-link-about" class="nav-link margin-right-large" href="#about-page" title="Informasjon om oss" onclick="toggleMobileMenuNavLink(this)">
                                 <svg class="nav-icon padding-top-mini" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-labelledby="about-nav-icon" role="img">
                                     <title id="about-nav-icon">Informasjon om oss</title>
                                     <use href="#about-icon"></use>
                                 </svg>
                                 Om oss
                             </a>
-                            <a class="nav-link margin-right-large" href="#find-page" title="Informasjon om hvordan du finner oss" onclick="toggleMobileMenuNavLink()">
+                            <a id="nav-link-find" class="nav-link margin-right-large" href="#find-page" title="Informasjon om hvordan du finner oss" onclick="toggleMobileMenuNavLink(this)">
                                 <svg class="nav-icon padding-top-mini" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-labelledby="find-nav-icon" role="img">
                                     <title id="find-nav-icon">Informasjon om hvordan du finner oss</title>
                                     <use href="#find-icon"></use>
                                 </svg>
                                 Finn oss
                             </a>
-                            <a class="nav-link margin-right-large" href="#diseases-page" title="Informasjon om øyesykdommer" onclick="toggleMobileMenuNavLink()">
+                            <a id="nav-link-disease" class="nav-link margin-right-large" href="#diseases-page" title="Informasjon om øyesykdommer" onclick="toggleMobileMenuNavLink(this)">
                                 <svg class="nav-icon padding-top-mini" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-labelledby="disease-nav-icon" role="img">
                                     <title id="disease-nav-icon">Informasjon om øyesykdommer</title>
                                     <use href="#disease-icon"></use>
                                 </svg>
                                 Øyesykdommer
                             </a>
-                            <a class="nav-link" href="#contact-page" title="Kontakt oss via telefon" onclick="toggleMobileMenuNavLink()">
+                            <a id="nav-link-contact" class="nav-link" href="#contact-page" title="Kontakt oss via telefon" onclick="toggleMobileMenuNavLink(this)">
                                 <svg class="nav-icon padding-top-mini" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-labelledby="telephone-nav-icon" role="img">
                                     <title id="telephone-nav-icon">Kontakt oss via telefon</title>
                                     <use href="#telephone-icon"></use>

--- a/navigation.js
+++ b/navigation.js
@@ -5,6 +5,7 @@ function toggleMobileMenu() {
     const navDiv = document.querySelector(".navbar-div");
     const continueIcon = document.querySelector(".continue-icon");
     const body = document.querySelector("body");
+    const topButton = document.querySelector(".to-top-button");
     const navLinks = document.querySelectorAll(".nav-link");
 
     if (!nav.classList.contains("responsive")) {
@@ -13,6 +14,13 @@ function toggleMobileMenu() {
         nav.classList.remove("padding-bottom-small");
         navDiv.classList.add("navbar-div-responsive");
         continueIcon.classList.add("continue-icon-responsive");
+
+        /* If top-button is visible, it should not be shown on the mobile menu. */
+        if (topButton.classList.contains("show")) {
+            topButton.classList.remove("show");
+            topButton.classList.add("triggered-by-menu"); /* If it was hidden by the menu */
+        }
+
         navLinks.forEach(link => link.classList.add("fadeInUp"));
     }   else {
         body.classList.remove("stop-scroll");
@@ -20,15 +28,23 @@ function toggleMobileMenu() {
         nav.classList.add("padding-bottom-small");
         navDiv.classList.remove("navbar-div-responsive");
         continueIcon.classList.remove("continue-icon-responsive");
+
+        /* If top-button was hidden by mobile menu, it should be shown again. */
+        if (topButton.classList.contains("triggered-by-menu")) {
+            topButton.classList.add("show");
+            topButton.classList.remove("triggered-by-menu");
+        }
+
         navLinks.forEach(link => link.classList.remove("fadeInUp"));
     }
 }
 
-function toggleMobileMenuNavLink() {
+function toggleMobileMenuNavLink(caller) {
     const nav = document.querySelector(".navbar");
     const navDiv = document.querySelector(".navbar-div");
     const continueIcon = document.querySelector(".continue-icon");
     const body = document.querySelector("body");
+    const topButton = document.querySelector(".to-top-button");
 
     if (nav.classList.contains("responsive")) {
         body.classList.remove("stop-scroll");
@@ -36,6 +52,17 @@ function toggleMobileMenuNavLink() {
         nav.classList.add("padding-bottom-small");
         navDiv.classList.remove("navbar-div-responsive");
         continueIcon.classList.remove("continue-icon-responsive");
+
+        /* Check if top-button should be shown again */
+        if (topButton.classList.contains("triggered-by-menu")) {
+            const showButtonCallers = ["nav-link-find", "nav-link-disease",
+                                       "nav-link-contact"];
+            /* If the scroll position requires the top-button to be visible */
+            if (showButtonCallers.includes(caller.id)) {
+                topButton.classList.add("show");
+                topButton.classList.remove("triggered-by-menu");
+            }
+        }
     }
 }
 


### PR DESCRIPTION
- Fix bug where top-button would show on the mobile menu

- Also restore top-button if it was visible before menu press

- Added onclick function to logo, allowing it to have similar functionality as the nav-links when the mobile menu is open.

This pull request closes #68.